### PR TITLE
update Mosquitto Debian Package-List URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get upgrade -y
 RUN apt-get install -y wget
 
 RUN wget -O - http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | apt-key add -
-RUN wget -O /etc/apt/sources.list.d/mosquitto-repo.list http://repo.mosquitto.org/debian/mosquitto-repo.list
+RUN wget -O /etc/apt/sources.list.d/mosquitto-repo.list http://repo.mosquitto.org/debian/mosquitto-jessie.list
 RUN apt-get update && apt-get install -y mosquitto
 
 RUN adduser --system --disabled-password --disabled-login mosquitto


### PR DESCRIPTION
The Debian Package-List URL was broken, so I checked at mosquitto.org and there are now seperate lists for debian releases. I therefore replaced the URL with http://repo.mosquitto.org/debian/mosquitto-jessie.list which works for me.