### PR TITLE
Added HTTPS for retriving the mosquitto repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Thomas Kerpe <toke@toke.de>
 
 
 RUN apt-get update && apt-get install -y wget && \
-    wget -q -O - http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | apt-key add - && \
-    wget -q -O /etc/apt/sources.list.d/mosquitto-jessie.list http://repo.mosquitto.org/debian/mosquitto-jessie.list && \
+    wget -q -O - https://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | apt-key add - && \
+    wget -q -O /etc/apt/sources.list.d/mosquitto-jessie.list https://repo.mosquitto.org/debian/mosquitto-jessie.list && \
     apt-get update && apt-get install -y mosquitto && \
     adduser --system --disabled-password --disabled-login mosquitto
 


### PR DESCRIPTION
Since yesterday repo.mosquitto.org supports HTTPS.
See the comments from 2016/03/08 under
   http://mosquitto.org/2013/01/mosquitto-debian-repository/#comments