### PR TITLE
Signalling fix for persistence.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ VOLUME ["/mqtt/config", "/mqtt/data", "/mqtt/log"]
 
 
 EXPOSE 1883 9001
-CMD /usr/sbin/mosquitto -c /mqtt/config/mosquitto.conf
+
+ADD docker-entrypoint.sh /usr/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/usr/sbin/mosquitto", "-c", "/mqtt/config/mosquitto.conf"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+exec "$@"


### PR DESCRIPTION
make mosquitto run as PID 1 in order to correctly catch signals from docker [[ref.](https://docs.docker.com/engine/reference/builder/#entrypoint)].

Now, on `docker stop` mosquitto correctly saves mosquitto.db for persistence