### PR TITLE
Fix for APT HTTPS transport and CA certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/passwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-type="Git" \
     org.label-schema.vcs-url="https://github.com/toke/docker-mosquitto"
 
-RUN apt-get update && apt-get install -y wget && \
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates && apt-get install -y wget && \
     wget -q -O - https://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | gpg --import && \
     gpg -a --export 8277CCB49EC5B595F2D2C71361611AE430993623 | apt-key add - && \
     wget -q -O /etc/apt/sources.list.d/mosquitto-jessie.list https://repo.mosquitto.org/debian/mosquitto-jessie.list && \

--- a/config/mosquitto.conf
+++ b/config/mosquitto.conf
@@ -5,6 +5,9 @@ pid_file /var/run/mosquitto.pid
 persistence true
 persistence_location /mqtt/data/
 
+password_file /mqtt/config/passwd
+allow_anonymous false
+
 user mosquitto
 
 # Port to use for the default listener.


### PR DESCRIPTION
Resolved an issue with APT and HTTPS downloading the packages

Added a passwd file and updated gitignore